### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frontest"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["Maciej Zwoliński <mac.zwolinski@gmail.com>"]
 repository = "https://github.com/zwo1in/frontest-rs"
@@ -21,9 +21,9 @@ readme = "README.md"
 default = ["yew"]
 
 [dependencies]
-gloo = { version = "0.6", features = ["futures"] }
-wasm-bindgen = "0.2.79"
-web-sys = { version = "0.3.56", features = [
+gloo = { version = "0.11", features = ["futures"] }
+wasm-bindgen = "0.2.89"
+web-sys = { version = "0.3", features = [
   "Document",
   "Element",
   "HtmlElement",
@@ -40,7 +40,7 @@ web-sys = { version = "0.3.56", features = [
   "NodeList",
 ] }
 
-yew = { version = "0.19", optional = true }
+yew = { version = "0.21", optional = true, features = ["csr"] }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -269,7 +269,8 @@ pub mod yew {
         let div = gloo::utils::document().create_element("div").unwrap();
         gloo::utils::body().append_child(&div).unwrap();
         let res = div.clone();
-        ::yew::start_app_with_props_in_element::<Wrapper>(div, WrapperProps { content });
+        ::yew::Renderer::<Wrapper>::with_root_and_props(div, WrapperProps { content }).render();
+        ::yew::platform::time::sleep(std::time::Duration::ZERO).await;
 
         res
     }
@@ -307,6 +308,8 @@ pub mod yew {
 
         assert_eq!("Value: 0", value.inner_text());
         button.click();
+        // Events are handled when the scheduler is yielded. So we need to add this after any interaction with the DOM.
+        ::yew::platform::time::sleep(std::time::Duration::ZERO).await;
         assert_eq!("Value: 1", value.inner_text());
 
         body().remove_child(&mount).unwrap();


### PR DESCRIPTION
Updates all dependencies. Most notably updates yew to version 0.21 to ensure compatibility with newer yew projects.

In Yew 0.21, we need to yield the thread to yew so events can be handled. Documented in the example code.